### PR TITLE
GCS backend parity (plan-only uses remote state) — m5/gcs-backend-parity-v2-20250817T050536Z

### DIFF
--- a/governance/GCS_BACKEND_PARITY_EVIDENCE_17017028227_20250817T050536Z.md
+++ b/governance/GCS_BACKEND_PARITY_EVIDENCE_17017028227_20250817T050536Z.md
@@ -1,0 +1,6 @@
+# GCS Backend Parity — Evidence
+- Run: https://github.com/Huyen1974/agent-data-test/actions/runs/17017028227
+- Branch: m5/gcs-backend-parity-v2-20250817T050536Z
+- Backend init step: ✓ Terraform init (GCS backend, read-only)
+- Plan: 2 to add, 7 to change, 0 to destroy.
+- UBLA: false→true=0, true→false=0

--- a/governance/GCS_BACKEND_PARITY_EVIDENCE_17017974196_20250817T065420Z.md
+++ b/governance/GCS_BACKEND_PARITY_EVIDENCE_17017974196_20250817T065420Z.md
@@ -1,0 +1,7 @@
+# GCS Backend Parity — Evidence
+
+- Run: https://github.com/Huyen1974/agent-data-test/actions/runs/17017974196
+- Branch: m5/gcs-backend-parity-v2-20250817T050536Z
+- Init step: present in job summary (see run page)
+- Plan: 2 to add, 7 to change, 0 to destroy.
+- UBLA: false→true=0, true→false=0


### PR DESCRIPTION
**What**: plan-only now inits GCS backend (-reconfigure) for parity with apply.
- Verification: ✓ Terraform init (GCS backend, read-only) step executed successfully
- Plan: 2 to add, 7 to change, 0 to destroy.
- UBLA audit: false→true=0, true→false=0 (must be 0 for true→false)

Evidence: `governance/GCS_BACKEND_PARITY_EVIDENCE_17017028227_20250817T050536Z.md`