### PR TITLE
tests/fixtures: Qdrant region us-east4

### DIFF
--- a/scripts/gen_fixtures.py
+++ b/scripts/gen_fixtures.py
@@ -41,7 +41,7 @@ def real_langroid_docchat_agent(query: str) -> dict[str, Any]:
 
     Uses:
     - OPENAI_API_KEY from environment
-    - Qdrant cluster (QDRANT_CLUSTER1_ID, QDRANT_CLUSTER1_KEY, asia-southeast1)
+    - Qdrant cluster (QDRANT_CLUSTER1_ID, QDRANT_CLUSTER1_KEY, us-east4)
     - Collection: test_documents (cleaned before run)
     - Embedding: text-embedding-3-small
     """
@@ -122,7 +122,7 @@ def real_langroid_docchat_agent(query: str) -> dict[str, Any]:
             "model_version": "langroid-0.58.0",
             "embedding_model": "text-embedding-3-small",
             "collection_name": "test_documents",
-            "qdrant_region": "asia-southeast1",
+            "qdrant_region": "us-east4",
             "mock_data": False,
         },
     }

--- a/tests/test_fixture_pipeline.py
+++ b/tests/test_fixture_pipeline.py
@@ -161,8 +161,8 @@ class TestFixturePipeline:
                     "qdrant_region" in metadata
                 ), f"{output_key} should have qdrant_region in real mode"
                 assert (
-                    metadata["qdrant_region"] == "asia-southeast1"
-                ), f"{output_key} should use asia-southeast1 region"
+                    metadata["qdrant_region"] == "us-east4"
+                ), f"{output_key} should use us-east4 region"
 
                 # Content should have collection_info for real mode
                 content = output_data["content"]


### PR DESCRIPTION
Update tests and fixture generator to use us-east4 per QD LAW.