### PR TITLE
M6 — bridge cloudrun workflows to main

### DIFF
--- a/.github/workflows/cloudrun-build.yml
+++ b/.github/workflows/cloudrun-build.yml
@@ -1,0 +1,73 @@
+name: Cloud Run Build (Manual)
+on:
+  workflow_dispatch:
+    inputs:
+      context:
+        description: Build context path
+        default: "."
+      skip_if_no_dockerfile:
+        description: Skip if no Dockerfile at context
+        type: boolean
+        default: true
+concurrency:
+  group: cloudrun-build-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+  id-token: write
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: ${{ secrets.GCP_REGION }}
+  AR_REPO: agent-data
+  SERVICE: agent-data-test
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Pre-check Dockerfile
+        id: precheck
+        shell: bash
+        run: |
+          CTX="${{ inputs.context }}"
+          if [[ "${{ inputs.skip_if_no_dockerfile }}" == "true" && ! -f "$CTX/Dockerfile" ]]; then
+            echo "no_dockerfile=true" >> "$GITHUB_OUTPUT"
+            echo "SKIP: No Dockerfile at $CTX — exiting 0 to avoid red CI."
+            exit 0
+          fi
+
+      - name: Ensure Artifact Registry exists
+        shell: bash
+        run: |
+          gcloud artifacts repositories describe "$AR_REPO" --location="$REGION" >/dev/null 2>&1 || \
+          gcloud artifacts repositories create "$AR_REPO" --repository-format=docker --location="$REGION" \
+            --description="Agent Data images" || echo "WARN: AR create may have failed (roles?)"
+
+      - name: Configure Docker to use gcloud
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Setup Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build & Push
+        if: steps.precheck.outputs.no_dockerfile != 'true'
+        shell: bash
+        run: |
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/${SERVICE}"
+          docker buildx build \
+            --platform linux/amd64 \
+            -t "$IMAGE:${GITHUB_SHA}" \
+            -t "$IMAGE:latest" \
+            --push "${{ inputs.context }}"

--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -1,0 +1,58 @@
+name: Cloud Run Deploy (Manual)
+on:
+  workflow_dispatch:
+    inputs:
+      image_tag:
+        description: Tag to deploy
+        default: "latest"
+      allow_unauthenticated:
+        description: Make service public
+        type: boolean
+        default: false
+      service:
+        description: Cloud Run service name
+        default: "agent-data-test"
+concurrency:
+  group: cloudrun-deploy-${{ github.ref }}
+  cancel-in-progress: true
+permissions:
+  contents: read
+  id-token: write
+env:
+  PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
+  REGION: ${{ secrets.GCP_REGION }}
+  AR_REPO: agent-data
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Auth to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Deploy
+        shell: bash
+        run: |
+          SERVICE="${{ inputs.service }}"
+          TAG="${{ inputs.image_tag }}"
+          IMAGE="${REGION}-docker.pkg.dev/${PROJECT_ID}/${AR_REPO}/${SERVICE}:${TAG}"
+          if [[ "${{ inputs.allow_unauthenticated }}" == "true" ]]; then
+            AUTH_FLAG="--allow-unauthenticated"
+          else
+            AUTH_FLAG="--no-allow-unauthenticated"
+          fi
+          gcloud run deploy "$SERVICE" \
+            --image "$IMAGE" \
+            --region "$REGION" \
+            --platform managed \
+            $AUTH_FLAG \
+            --quiet


### PR DESCRIPTION
Infra-only: add manual Cloud Run workflows to default branch (enable workflow_dispatch on ref=feat/m6-cloudrun-cicd).