### PR TITLE
feat: add visible flag to report client

### DIFF
--- a/tests/test_save_report_script.py
+++ b/tests/test_save_report_script.py
@@ -91,7 +91,7 @@ def test_save_report_script_posts_valid_payload(tmp_path: Path) -> None:
     assert payload["content"]["mime_type"] == "text/markdown"
     assert "Weekly Report" in payload["content"]["body"]
     assert set(payload["metadata"]["tags"]) == {"report", "qa"}
-    assert payload["is_human_readable"] is True
+    assert payload["is_human_readable"] is False
 
 
 @pytest.mark.unit
@@ -141,3 +141,48 @@ def test_save_report_script_fetches_api_key_when_missing(tmp_path: Path) -> None
     assert server.requests, "Expected a request after secret fetch"
     request = server.requests[0]
     assert request["headers"].get("x-api-key") == "fetched-secret"
+
+    payload = json.loads(request["body"])
+    assert payload["is_human_readable"] is False
+
+
+@pytest.mark.unit
+def test_save_report_script_sets_visible_flag(tmp_path: Path) -> None:
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "scripts" / "client" / "save_report.sh"
+
+    class _Server(TCPServer):
+        allow_reuse_address = True
+
+    server = _Server(("127.0.0.1", 0), _CaptureHandler)
+    server.requests = []  # type: ignore[attr-defined]
+
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        port = server.server_address[1]
+        report_path = tmp_path / "report.md"
+        report_path.write_text("Visible report", encoding="utf-8")
+
+        with temporary_env(
+            AGENT_DATA_API_KEY="visible-secret",
+            AGENT_DATA_BASE_URL=f"http://127.0.0.1:{port}",
+        ):
+            result = subprocess.run(
+                [str(script_path), "--visible", "Visible Title", str(report_path)],
+                cwd=repo_root,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+        assert result.returncode == 0, result.stderr
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()
+
+    assert server.requests, "Expected request when using --visible"
+    payload = json.loads(server.requests[0]["body"])
+    assert payload["is_human_readable"] is True


### PR DESCRIPTION
## Summary
- allow save_report.sh to accept an optional --visible flag toggling is_human_readable
- expand unit tests to cover default hidden and visible report cases while exercising gcloud secret loading

## Testing
- pytest --no-cov tests/test_save_report_script.py
- pytest --no-cov tests/test_server.py -m unit
- pre-commit run --all-files
