### PR TITLE
feat: provision Agent Data API key secret

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,7 +1,9 @@
 module "agent_data_service_test" {
-  source       = "./modules/cloud_run_service"
-  project_id   = "github-chatgpt-ggcloud"
-  location     = "asia-southeast1"
-  service_name = "agent-data-test"
-  image_path   = "asia-southeast1-docker.pkg.dev/github-chatgpt-ggcloud/agent-data-test/agent-data-test:latest"
+  source                 = "./modules/cloud_run_service"
+  project_id             = "github-chatgpt-ggcloud"
+  location               = "asia-southeast1"
+  service_name           = "agent-data-test"
+  image_path             = "asia-southeast1-docker.pkg.dev/github-chatgpt-ggcloud/agent-data-test/agent-data-test:latest"
+  api_key_secret         = google_secret_manager_secret.agent_data_api_key.secret_id
+  api_key_secret_version = google_secret_manager_secret_version.agent_data_api_key.version
 }

--- a/terraform/modules/cloud_run_service/main.tf
+++ b/terraform/modules/cloud_run_service/main.tf
@@ -14,6 +14,19 @@ resource "google_cloud_run_v2_service" "default" {
   template {
     containers {
       image = var.image_path
+
+      dynamic "env" {
+        for_each = var.api_key_secret == null ? [] : [var.api_key_secret]
+        content {
+          name = "API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = var.api_key_secret
+              version = var.api_key_secret_version
+            }
+          }
+        }
+      }
     }
   }
 }

--- a/terraform/modules/cloud_run_service/variables.tf
+++ b/terraform/modules/cloud_run_service/variables.tf
@@ -17,3 +17,15 @@ variable "image_path" {
   description = "Container image path in Artifact Registry"
   type        = string
 }
+
+variable "api_key_secret" {
+  description = "Optional Secret Manager secret name for the API key"
+  type        = string
+  default     = null
+}
+
+variable "api_key_secret_version" {
+  description = "Secret Manager version for the API key"
+  type        = string
+  default     = "latest"
+}

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 4.84"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
     archive = {
       source  = "hashicorp/archive"
       version = ">= 2.4.0"

--- a/terraform/secrets.tf
+++ b/terraform/secrets.tf
@@ -18,3 +18,32 @@ resource "google_secret_manager_secret" "qdrant_api" {
     managed_by  = "terraform"
   }
 }
+
+resource "random_password" "agent_data_api_key" {
+  length  = 48
+  special = false
+}
+
+resource "google_secret_manager_secret" "agent_data_api_key" {
+  secret_id = "AGENT_DATA_API_KEY"
+  project   = var.project_id
+
+  replication {
+    user_managed {
+      replicas {
+        location = "asia-southeast1"
+      }
+    }
+  }
+
+  labels = {
+    environment = var.env
+    project     = "agent-data-langroid"
+    managed_by  = "terraform"
+  }
+}
+
+resource "google_secret_manager_secret_version" "agent_data_api_key" {
+  secret      = google_secret_manager_secret.agent_data_api_key.id
+  secret_data = random_password.agent_data_api_key.result
+}


### PR DESCRIPTION
## Summary
- generate a dedicated Agent Data API key via Secret Manager using Terraform
- expose the secret to Cloud Run as API_KEY env var
- add random provider dependency

## Testing
- terraform apply -auto-approve -var="enable_github_branch_protection=false"
- pre-commit run --all-files