### PR TITLE
fix: enable Firebase logout

### DIFF
--- a/app-service-project/src/App.vue
+++ b/app-service-project/src/App.vue
@@ -284,7 +284,7 @@ async function handleEmailSignup() {
   }
 }
 
-async function signOutUser() {
+async function handleLogout() {
   try {
     await signOut(auth);
     showSnackbar('Đã đăng xuất khỏi hệ thống.', 'info');
@@ -438,7 +438,7 @@ onMounted(() => {
           variant="text"
           color="primary"
           prepend-icon="mdi-logout"
-          @click="signOutUser"
+          @click="handleLogout"
         >
           Đăng xuất
         </v-btn>


### PR DESCRIPTION
## Summary
- rename local logout helper to handleLogout for clarity
- hook the toolbar button to the new handler so it invokes firebase signOut