### PR TITLE
Fix Guard Bootstrap workflow path

### DIFF
--- a/.github/workflows/guard_bootstrap.yml
+++ b/.github/workflows/guard_bootstrap.yml
@@ -9,6 +9,6 @@ jobs:
         run: |
           test -x bootstrap/bin/bootstrap_gh.sh
           test -x bootstrap/bin/sop_bootstrap_check.sh
-          test -x scripts/bootstrap_gh.sh
+          test -x tools/bootstrap_gh.sh
           test -x scripts/sop_bootstrap_check.sh
           test -x CLI.POSTBOOT.250.sh


### PR DESCRIPTION
## Summary
- point Guard Bootstrap workflow to the maintained tools/bootstrap_gh.sh wrapper
- ensure guard check matches current bootstrap tooling layout

## Testing
- bash -lc 'test -x bootstrap/bin/bootstrap_gh.sh && test -x bootstrap/bin/sop_bootstrap_check.sh && test -x tools/bootstrap_gh.sh && test -x scripts/sop_bootstrap_check.sh && test -x CLI.POSTBOOT.250.sh'