### PR TITLE
Add move document API endpoint

### DIFF
--- a/docs/specs/MCP_v2.md
+++ b/docs/specs/MCP_v2.md
@@ -222,6 +222,20 @@ Mọi request/response **MUST** gói trong Envelope sau. `payload.args` theo JSO
 
 **Semantics.** Cấm tạo chu kỳ; nếu có `before` thì reorder siblings, ngược lại append.
 
+**HTTP Endpoint.**
+
+`POST /documents/{doc_id}/move`
+
+**Request Body**
+
+```json
+{
+  "new_parent_id": "<string>"
+}
+```
+
+Response tuân theo §4 (`ok` envelope) với `data` chứa `{ "id", "status", "revision" }` sau khi cập nhật.
+
 ### 8.5 `knowledge.query_knowledge` (v1.0.0)
 
 **Args**


### PR DESCRIPTION
## Summary
- document POST /documents/{doc_id}/move contract in MCP spec
- simplify move payload to take only new_parent_id and update Firestore parent
- add unit coverage for minimal payload move behaviour

## Testing
- pytest
- pre-commit run --all-files