### PR TITLE
Wire Cursor custom commands for Agent Data

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,0 +1,38 @@
+# Cursor Command Helpers
+
+This directory hosts wrappers that make it easier to call the Agent Data APIs from within Cursor.
+
+## Available commands
+
+| Command | Description | Under the hood |
+|---------|-------------|----------------|
+| `@save_report <file_path> [--title <title>] [--parent <id>] [--visible]` | Uploads a local Markdown/JSON report through the create document API. | Executes `.cursor/commands/save_report.sh`, which forwards to `tools/save_report.sh`. |
+| `@move_document <doc_id> --to <new_parent_id> [--base-url <url>] [--dry-run]` | Moves a document to a new parent in the knowledge tree. | Executes `.cursor/commands/move_document.sh`, which posts to `POST /documents/{doc_id}/move`. |
+
+> Cursor's chat UI treats commands prefixed with `@` as shortcuts. When running from a shell, invoke the scripts directly (e.g. `.cursor/commands/move_document.sh ...`).
+
+## Usage from a shell session
+
+1. Ensure the environment is configured:
+   - `AGENT_DATA_API_KEY` (required; if missing, the scripts will attempt to read it from Secret Manager via `gcloud`).
+   - `AGENT_DATA_BASE_URL` (optional; defaults to `http://localhost:8000`).
+   - `AGENT_DATA_PARENT_ID`, `AGENT_DATA_REPORT_TAGS` (optional for `@save_report`).
+
+2. Call the wrapper scripts, for example:
+   ```bash
+   ./.cursor/commands/save_report.sh reports/week42.md --title "Week 42" --visible
+   ./.cursor/commands/move_document.sh doc-abc --to folder-root
+   ```
+   The scripts return non-zero exit codes (and print diagnostic JSON) if the API rejects the request.
+
+3. For automation in Cursor chat, define a custom command pointing to the wrapper script (see `.cursor/commands.yaml`).
+
+### Dry-run support
+
+Append `--dry-run` to `@move_document` to print the generated `curl` call without mutating data. This is helpful for validating configuration in CI or during onboarding.
+
+### Dependencies
+
+- `curl`
+- `python3`
+- optional `gcloud` (only needed if the API key is retrieved from Secret Manager)

--- a/.cursor/RULES_agent-data-langroid.md
+++ b/.cursor/RULES_agent-data-langroid.md
@@ -181,6 +181,18 @@ Nguyên tắc: Mọi thay đổi về số lượng file trong thư mục tests/
   ```
 - Script sẽ tạo payload `create_document` theo MCP v2 và trả về phản hồi API (HTTP 2xx là thành công).
 
+### Cursor Custom Commands (CLI helpers)
+- `@save_report <file_path> [--title <title>] [--parent <id>] [--visible]`
+  - Wrapper: `.cursor/commands/save_report.sh`
+  - Hành động: Nội suy tham số, sau đó gọi `tools/save_report.sh`.
+  - Ghi chú: cần `AGENT_DATA_API_KEY` (hoặc gcloud đã cấu hình) và tôn trọng `AGENT_DATA_BASE_URL`.
+- `@move_document <doc_id> --to <new_parent_id> [--base-url <url>] [--dry-run]`
+  - Wrapper: `.cursor/commands/move_document.sh`
+  - Hành động: Gọi API `POST /documents/{doc_id}/move` (cập nhật `parent_id`).
+  - Ghi chú: sử dụng `tools/move_document.sh`; nếu `--dry-run` sẽ chỉ in câu lệnh `curl`.
+
+> Khi chạy `@` commands trong Cursor shell, có thể gọi trực tiếp các wrapper `.cursor/commands/*.sh` hoặc tạo alias tương ứng trong session.
+
 ---
 
 ## 9. Báo cáo & tự sửa lỗi (strict)

--- a/.cursor/commands.yaml
+++ b/.cursor/commands.yaml
@@ -1,0 +1,15 @@
+commands:
+  - name: "@save_report"
+    description: "Upload a local report file to Agent Data via tools/save_report.sh"
+    usage: "@save_report <file_path> [--title <title>] [--parent <parent_id>] [--visible]"
+    runner: ".cursor/commands/save_report.sh"
+    requirements:
+      - "AGENT_DATA_API_KEY must be available or retrievable via gcloud"
+      - "Optional: AGENT_DATA_BASE_URL, AGENT_DATA_PARENT_ID, AGENT_DATA_REPORT_TAGS"
+  - name: "@move_document"
+    description: "Move an existing document to a new parent node"
+    usage: "@move_document <doc_id> --to <new_parent_id> [--base-url <url>] [--dry-run]"
+    runner: ".cursor/commands/move_document.sh"
+    requirements:
+      - "AGENT_DATA_API_KEY or --api-key override"
+      - "Optional: AGENT_DATA_BASE_URL"

--- a/.cursor/commands/move_document.sh
+++ b/.cursor/commands/move_document.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: @move_document <doc_id> --to <new_parent_id> [--base-url <url>] [--dry-run]
+
+Wrapper around tools/move_document.sh to move documents inside the knowledge tree.
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+if [[ $1 == "--help" || $1 == "-h" ]]; then
+    usage
+    exit 0
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+MOVE_SCRIPT="$ROOT_DIR/tools/move_document.sh"
+
+if [[ ! -x "$MOVE_SCRIPT" ]]; then
+    echo "❌ Expected helper script not executable: $MOVE_SCRIPT" >&2
+    exit 1
+fi
+
+"$MOVE_SCRIPT" "$@"

--- a/.cursor/commands/save_report.sh
+++ b/.cursor/commands/save_report.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: @save_report <file_path> [--title <title>] [--parent <parent_id>] [--visible]
+
+Wraps tools/save_report.sh so Cursor helpers can quickly upload reports.
+
+Options:
+  --title <title>     Optional human friendly title (defaults to file name)
+  --parent <id>       Overrides target parent document (default $AGENT_DATA_PARENT_ID or "root")
+  --visible           Pass through --visible to expose content in the web UI
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+FILE_PATH=$1
+shift
+
+TITLE=""
+PARENT_ID="${AGENT_DATA_PARENT_ID:-root}"
+VISIBLE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --title)
+            TITLE=${2:-}
+            shift 2
+            ;;
+        --parent)
+            PARENT_ID=${2:-}
+            shift 2
+            ;;
+        --visible)
+            VISIBLE=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "❌ Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ ! -f "$FILE_PATH" ]]; then
+    echo "❌ File not found: $FILE_PATH" >&2
+    exit 1
+fi
+
+if [[ -z "$TITLE" ]]; then
+    TITLE=$(basename "$FILE_PATH")
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SAVE_SCRIPT="$ROOT_DIR/tools/save_report.sh"
+
+if [[ ! -x "$SAVE_SCRIPT" ]]; then
+    echo "❌ Expected helper script not executable: $SAVE_SCRIPT" >&2
+    exit 1
+fi
+
+if [[ "$VISIBLE" == "true" ]]; then
+    "$SAVE_SCRIPT" --visible "$TITLE" "$FILE_PATH" "$PARENT_ID"
+else
+    "$SAVE_SCRIPT" "$TITLE" "$FILE_PATH" "$PARENT_ID"
+fi

--- a/tools/move_document.sh
+++ b/tools/move_document.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'USAGE' >&2
+Usage: move_document.sh <doc_id> --to <new_parent_id> [--base-url <url>] [--api-key <key>] [--dry-run]
+
+Updates parent_id of an existing document through the Agent Data API.
+
+Environment variables:
+  AGENT_DATA_API_KEY   (required if --api-key not provided)
+  AGENT_DATA_BASE_URL  (optional, default http://localhost:8000)
+USAGE
+}
+
+if [[ $# -lt 1 ]]; then
+    usage
+    exit 1
+fi
+
+DOC_ID=$1
+shift || true
+
+if [[ -z "$DOC_ID" ]]; then
+    echo "❌ document id is required" >&2
+    usage
+    exit 1
+fi
+
+NEW_PARENT_ID=""
+BASE_URL="${AGENT_DATA_BASE_URL:-http://localhost:8000}"
+OVERRIDE_API_KEY=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --to)
+            NEW_PARENT_ID=${2:-}
+            shift 2
+            ;;
+        --base-url)
+            BASE_URL=${2:-}
+            shift 2
+            ;;
+        --api-key)
+            OVERRIDE_API_KEY=${2:-}
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=true
+            shift
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "❌ Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z "$NEW_PARENT_ID" ]]; then
+    echo "❌ new parent id is required" >&2
+    usage
+    exit 1
+fi
+
+API_KEY="$OVERRIDE_API_KEY"
+
+if [[ -z "$API_KEY" ]]; then
+    if [[ -n "${AGENT_DATA_API_KEY:-}" ]]; then
+        API_KEY="$AGENT_DATA_API_KEY"
+    elif command -v gcloud >/dev/null 2>&1; then
+        echo "ℹ️  Fetching AGENT_DATA_API_KEY from Secret Manager" >&2
+        if ! API_KEY=$(gcloud secrets versions access latest --secret="AGENT_DATA_API_KEY" 2>/tmp/move_document_gcloud_err); then
+            echo "❌ Failed to load AGENT_DATA_API_KEY via gcloud" >&2
+            cat /tmp/move_document_gcloud_err >&2 || true
+            rm -f /tmp/move_document_gcloud_err
+            exit 1
+        fi
+        rm -f /tmp/move_document_gcloud_err
+    else
+        echo "❌ AGENT_DATA_API_KEY is not set and gcloud is unavailable" >&2
+        exit 1
+    fi
+fi
+
+BASE_URL=${BASE_URL%/}
+ENDPOINT="$BASE_URL/documents/$DOC_ID/move"
+
+payload=$(python3 - "$NEW_PARENT_ID" <<'PY'
+import json
+import sys
+new_parent = sys.argv[1]
+print(json.dumps({"new_parent_id": new_parent}))
+PY
+)
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    printf 'curl -sS -X POST %q -H "Content-Type: application/json" -H "x-api-key: $API_KEY" -d %q\n' "$ENDPOINT" "$payload"
+    exit 0
+fi
+
+TMP_RESPONSE=$(mktemp)
+trap 'rm -f "$TMP_RESPONSE"' EXIT
+
+HTTP_CODE=$(curl -sS -X POST "$ENDPOINT" \
+    -H "Content-Type: application/json" \
+    -H "x-api-key: $API_KEY" \
+    -d "$payload" \
+    -w "%{http_code}" \
+    -o "$TMP_RESPONSE")
+
+if [[ $HTTP_CODE -ge 200 && $HTTP_CODE -lt 300 ]]; then
+    echo "✅ Document $DOC_ID moved to $NEW_PARENT_ID"
+    cat "$TMP_RESPONSE"
+    echo
+else
+    echo "❌ Failed to move document (HTTP $HTTP_CODE)" >&2
+    cat "$TMP_RESPONSE" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary
- add shell wrappers under .cursor/commands to expose @save_report and @move_document helpers
- document the shortcuts in .cursor/commands.yaml and README for quick onboarding
- provide a reusable tools/move_document.sh script that performs the API call

## Testing
- pre-commit run --all-files