### PR TITLE
fix: guard auth-only routes

### DIFF
--- a/app-service-project/src/router/index.js
+++ b/app-service-project/src/router/index.js
@@ -1,6 +1,20 @@
 import { createRouter, createWebHistory } from 'vue-router';
+import { auth } from '@/firebase/config'; // Using alias for cleaner path
 
 import KnowledgeHubView from '../views/KnowledgeHubView.vue';
+
+// Helper to get current user state asynchronously
+const getCurrentUser = () => {
+  return new Promise((resolve, reject) => {
+    const unsubscribe = auth.onAuthStateChanged(
+      user => {
+        unsubscribe();
+        resolve(user);
+      },
+      reject
+    );
+  });
+};
 
 const routes = [
   {
@@ -9,7 +23,7 @@ const routes = [
     component: KnowledgeHubView,
     meta: {
       title: 'Knowledge Hub',
-      description: 'Tổng quan trung tâm tri thức (placeholder).',
+      description: 'Tổng quan trung tâm tri thức.',
     },
   },
   {
@@ -18,7 +32,8 @@ const routes = [
     component: KnowledgeHubView,
     meta: {
       title: 'Portal Nội Bộ',
-      description: 'Phân khu nội bộ (placeholder).',
+      description: 'Phân khu nội bộ.',
+      requiresAuth: true, // This route requires authentication
     },
   },
   {
@@ -27,7 +42,8 @@ const routes = [
     component: KnowledgeHubView,
     meta: {
       title: 'Portal Kinh Doanh',
-      description: 'Phân khu kinh doanh (placeholder).',
+      description: 'Phân khu kinh doanh.',
+      requiresAuth: true, // This route requires authentication
     },
   },
 ];
@@ -36,6 +52,26 @@ const router = createRouter({
   history: createWebHistory(),
   routes,
   scrollBehavior: () => ({ top: 0 }),
+});
+
+// Global Navigation Guard
+router.beforeEach(async (to, from, next) => {
+  const requiresAuth = to.matched.some(record => record.meta.requiresAuth);
+
+  if (requiresAuth) {
+    const user = await getCurrentUser();
+    if (!user) {
+      // User is not logged in, redirect to the home page.
+      console.log('Unauthorized access attempt to a protected route. Redirecting to /.');
+      next({ name: 'home' });
+    } else {
+      // User is logged in, allow access.
+      next();
+    }
+  } else {
+    // Route does not require auth, allow access.
+    next();
+  }
 });
 
 export default router;


### PR DESCRIPTION
## Summary
- reuse Firebase auth state to protect internal portal routes
- add navigation guard redirecting anonymous users back to home

## Testing
- npm run build --prefix app-service-project