### PR TITLE
ci: skip terraform plan on dependabot branches

### DIFF
--- a/.github/workflows/lint-only.yml
+++ b/.github/workflows/lint-only.yml
@@ -191,6 +191,7 @@ jobs:
 
   terraform-plan:
     name: Terraform Plan (CPG0.1)
+    if: ${{ !startsWith(github.actor, 'dependabot') }}
     runs-on: ubuntu-22.04
     needs: checkpoint-gate
     timeout-minutes: 25            # hard-stop sau 25 phút


### PR DESCRIPTION
## Summary\n- skip the terraform plan job when the workflow is running under dependabot\n\n## Testing\n- pre-commit run --all-files